### PR TITLE
Added multi extension support.

### DIFF
--- a/index.js
+++ b/index.js
@@ -9,13 +9,27 @@ exports.prepare = function (extensions, filepath, cwd, nothrow) {
   var attempts = [];
   var err;
   var onlyErrors = false;
-  var ext = extension(filepath);
-  if (Object.keys(require.extensions).indexOf(ext) !== -1) {
+  var exts = extension(filepath);
+
+  var supportsExtension = exts.some(function(ext) {
+    return Object.keys(require.extensions).indexOf(ext) !== -1;
+  });
+
+  if (supportsExtension) {
     return true;
   }
-  var config = normalize(extensions[ext]);
+
+  var config;
+  exts.some(function(ext) {
+    config = normalize(extensions[ext]);
+    if (config) {
+      return true;
+    }
+    return false;
+  });
+
   if (!config) {
-    throw new Error('No module loader found for "'+ext+'".');
+    throw new Error('No module loader found for "'+exts+'".');
   }
   if (!cwd) {
     cwd = path.dirname(path.resolve(filepath));
@@ -43,7 +57,7 @@ exports.prepare = function (extensions, filepath, cwd, nothrow) {
     }
   }
   if (onlyErrors) {
-    err = new Error('Unable to use specified module loaders for "'+ext+'".');
+    err = new Error('Unable to use specified module loaders for "'+exts+'".');
     err.failures = attempts;
     if (nothrow) {
       return err;

--- a/lib/extension.js
+++ b/lib/extension.js
@@ -1,11 +1,11 @@
 const path = require('path');
 
-const EXTRE = /^[.]?[^.]+([.].*)$/;
+const EXTRE = /(\.[^.]+)+$/;
 
 module.exports = function (input) {
-  var extension = EXTRE.exec(path.basename(input));
-  if (!extension) {
+  var possibleExtensions = EXTRE.exec(path.basename(input));
+  if (!possibleExtensions) {
     return;
   }
-  return extension[1];
+  return possibleExtensions;
 };

--- a/test/fixtures/test.babel.js
+++ b/test/fixtures/test.babel.js
@@ -1,10 +1,9 @@
-// Test ES6 arrow functions
-var fn = () => {
-  var trueKey = true;
-  var falseKey = false;
-  var subKey = { subProp: 1 };
-  // Test harmony object short notation
-  return { data: { trueKey, falseKey, subKey}};
+module.exports = {
+  data: {
+    trueKey: true,
+    falseKey: false,
+    subKey: {
+      subProp: 1
+    }
+  }
 };
-
-module.exports = fn();

--- a/test/index.js
+++ b/test/index.js
@@ -24,10 +24,6 @@ process.env.TYPESCRIPT_REGISTER_USE_CACHE = 'false';
 
 describe('rechoir', function () {
 
-  require('./lib/extension');
-  require('./lib/normalize');
-  require('./lib/register');
-
   describe('prepare', function () {
     var testFilePath = path.join(__dirname, 'fixtures', 'test.coffee');
 

--- a/test/lib/extension.js
+++ b/test/lib/extension.js
@@ -5,10 +5,11 @@ const extension = require('../../lib/extension');
 describe('extension', function () {
 
   it('should extract extension from filename/path from the first dot', function () {
-    expect(extension('file.js')).to.equal('.js');
-    expect(extension('file.dot.js')).to.equal('.dot.js');
-    expect(extension('relative/path/to/file.js')).to.equal('.js');
-    expect(extension('relative/path/to/file.dot.js')).to.equal('.dot.js');
+    expect(extension('file.js')[0]).to.equal('.js');
+    expect(extension('file.dot.js')[0]).to.equal('.dot.js');
+    expect(extension('file.dot.js')[1]).to.equal('.js');
+    expect(extension('relative/path/to/file.js')[0]).to.equal('.js');
+    expect(extension('relative/path/to/file.dot.js')[0]).to.equal('.dot.js');
+    expect(extension('relative/path/to/file.dot.js')[1]).to.equal('.js');
   });
-  
 });


### PR DESCRIPTION
I understand the convention for babel files is `babel.js` and this plugin has to provide support for that. But I'm using some other framework which names temporary files as `file.tmp.js`. This PR aims to fix issue #24.