### PR TITLE
Simplify logic and add test coverage for "only errors" prepare() calls

### DIFF
--- a/index.js
+++ b/index.js
@@ -8,7 +8,7 @@ exports.prepare = function (extensions, filepath, cwd, nothrow) {
   var option, attempt;
   var attempts = [];
   var err;
-  var onlyErrors = false;
+  var onlyErrors = true;
   var ext = extension(filepath);
   if (Object.keys(require.extensions).indexOf(ext) !== -1) {
     return true;
@@ -42,8 +42,6 @@ exports.prepare = function (extensions, filepath, cwd, nothrow) {
     if (!error) {
       onlyErrors = false;
       break;
-    } else {
-      onlyErrors = true;
     }
   }
   if (onlyErrors) {

--- a/test/index.js
+++ b/test/index.js
@@ -52,15 +52,16 @@ describe('rechoir', function () {
       }).to.throw;
     });
 
-    it('should include errors for each module loader that was attempted if they failed to load', function () {
-      try {
-        rechoir.prepare({
-          '.coffee': [
-            'nothere',
-            'orhere'
-          ]
-        }, testFilePath);
-      } catch (e) {
+    describe('all module loaders that were attempted failed to load', function () {
+      var exts = {
+        '.coffee': [
+          'nothere',
+          'orhere'
+        ]
+      };
+
+      // Check the failure entries in the thrown or returned error object.
+      function check_failures (e) {
         expect(e.failures).to.be.an('array');
         expect(e.failures[0].error).to.be.instanceof(Error);
         expect(e.failures[0].moduleName).to.equal('nothere');
@@ -69,6 +70,23 @@ describe('rechoir', function () {
         expect(e.failures[1].moduleName).to.equal('orhere');
         expect(e.failures[1].module).to.be.null;
       }
+
+      it('should throw error listing each module loader that was attempted when nothrow = false', function () {
+        var err;
+        try {
+          rechoir.prepare(exts, testFilePath);
+        } catch (e) {
+          err = e;
+          check_failures(e);
+        }
+        expect(err).to.be.instanceof(Error);
+      });
+
+      it('should return error listing each module loader that was attempted when nothrow = true', function () {
+        check_failures(
+          rechoir.prepare(exts, testFilePath, null, true)
+        );
+      });
     });
 
     it('should register a module loader for the specified extension', function () {

--- a/test/index.js
+++ b/test/index.js
@@ -61,7 +61,7 @@ describe('rechoir', function () {
           ]
         }, testFilePath);
       } catch (e) {
-        expect(e.failures).to.be.array;
+        expect(e.failures).to.be.an('array');
         expect(e.failures[0].error).to.be.instanceof(Error);
         expect(e.failures[0].moduleName).to.equal('nothere');
         expect(e.failures[0].module).to.be.null;


### PR DESCRIPTION
* Simplify the `onlyErrors` logic by assuming `true` until it's not. It doesn't make sense to initialize it to `false`. Can you think of a case where this change would break something? The tests pass.

* Add test coverage for "only errors" `prepare()` calls with `nothrow = true`.

* Fix a broken expectation.